### PR TITLE
Use do_jit to speed up I/O loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ This service uses Decalage's ViperMonkey (https://github.com/decalage2/ViperMonk
         network.static.uri
         network.port
         technique.macro
+
+### Safety
+
+ViperMonkey may use eval() to speed up emulation. This service should be run in a sandboxed environment, which Assemblyline does by default for non-privileged services. This service should not be run in privileged mode.

--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -16,6 +16,8 @@ enabled: true
 is_external: false
 licence_count: 0
 
+privileged: false # Warning: ViperMonkey may use eval, do not set to true
+
 heuristics:
   - heur_id: 1
     name: ViperMonkey Error

--- a/vipermonkey_compat.py2
+++ b/vipermonkey_compat.py2
@@ -54,6 +54,7 @@ if __name__ == "__main__":
             vmonkey_values = process_file(None, file_to_scan, None,
                                           strip_useless=False, # Todo: fixes for strip_useless?
                                           display_int_iocs=True,
+                                          do_jit=True, # Warning: uses eval, do not use service in privileged mode
                                           artifact_dir=sys.argv[2] if len(sys.argv) > 2 else None)
 
             # Release stdout and stderr


### PR DESCRIPTION
Warning this option uses eval. Vipermonkey should not be run
as a privileged service.

fixes #32