### PR TITLE
Shell Function Found alone shouldn't be able to lable a file malicious

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -28,6 +28,7 @@ heuristics:
   - heur_id: 2
     name: Shell Function Found
     score: 100
+    max_score: 500
     filetype: (document/.*|code/xml)
     description: Shell function found by ViperMonkey
 


### PR DESCRIPTION
Some legitimate excel files have a number of internet explorer calls
that combine to give a malicious verdict. Capping score at 500.