### PR TITLE
Remove depricated python vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,21 +18,15 @@
         "--profile=black",
         // "--src=${workspaceFolder}"
     ],
-    "python.formatting.autopep8Args": [
-        "--max-line-length",
-        "120",
-        "--experimental"
-    ],
-    "python.formatting.provider": "autopep8",
-    "python.formatting.blackArgs": [
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "black-formatter.args": [
         "--line-length=120"
     ],
-    "python.linting.enabled": true,
-    "python.linting.flake8Enabled": true,
-    "python.linting.flake8Args": [
+    "flake8.args": [
         "--max-line-length=120",
         //Added the ignore of E203 for now : https://github.com/PyCQA/pycodestyle/issues/373
         "--ignore=E203,W503"
     ],
-    "python.linting.pylintEnabled": false,
 }


### PR DESCRIPTION
The python vscode extension is switching from having formatters and linters bundled to having separate extensions. Switch the old vscode python settings to the new separate extension settings.