### PR TITLE
Increasing memory from 2GB to 8GB in service_manifest

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -80,4 +80,4 @@ heuristics:
 docker_config:
   image: ${REGISTRY}cccs/assemblyline-service-vipermonkey:$SERVICE_TAG
   cpu_cores: 1
-  ram_mb: 2048
+  ram_mb: 8192


### PR DESCRIPTION
On some samples vipermonkey uses a lot of memory but still completes in a reasonable amount of time.